### PR TITLE
Add GitHub API call to list repositories

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,23 @@
 import Image from "next/image";
+import { useEffect, useState } from "react";
 
 export default function Home() {
+  const [repositories, setRepositories] = useState([]);
+
+  useEffect(() => {
+    fetch("https://api.github.com/users/tgrall/repos")
+      .then((response) => response.json())
+      .then((data) => {
+        const repoData = data.map((repo) => ({
+          name: repo.name,
+          stars: repo.stargazers_count,
+        }));
+        setRepositories(repoData);
+      });
+  }, []);
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+    <main className="flex min-h-screen flex-col items-center justify-between p-24 bg-black text-yellow-400">
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
           Get started by editing&nbsp;
@@ -40,73 +55,12 @@ export default function Home() {
       </div>
 
       <div className="mb-32 grid text-center lg:mb-0 lg:w-full lg:max-w-5xl lg:grid-cols-4 lg:text-left">
-        <a
-          href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Docs{" "}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Find in-depth information about Next.js features and API.
-          </p>
-        </a>
-
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Learn{" "}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Learn about Next.js in an interactive course with&nbsp;quizzes!
-          </p>
-        </a>
-
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Templates{" "}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Explore starter templates for Next.js.
-          </p>
-        </a>
-
-        <a
-          href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Deploy{" "}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-balance text-sm opacity-50">
-            Instantly deploy your Next.js site to a shareable URL with Vercel.
-          </p>
-        </a>
+        {repositories.map((repo) => (
+          <div key={repo.name} className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30">
+            <h2 className="mb-3 text-2xl font-semibold">{repo.name}</h2>
+            <p className="m-0 max-w-[30ch] text-sm opacity-50">Stars: {repo.stars}</p>
+          </div>
+        ))}
       </div>
     </main>
   );

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+# Project Documentation
+
+## Framework Version
+
+This project uses Next.js version 14.2.3.
+
+## API Call Sequence
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App
+    participant GitHubAPI
+    User->>App: Request homepage
+    App->>GitHubAPI: Fetch repositories of tgrall
+    GitHubAPI-->>App: Return repositories data
+    App-->>User: Display repositories and star counts
+```


### PR DESCRIPTION
Related to #1

This pull request introduces functionality to dynamically fetch and display GitHub repositories and their star counts on the homepage, alongside updating the page's aesthetic to match the specified design.

- **Implements API Call**: Adds logic to `app/page.tsx` to fetch the list of repositories from GitHub's API for the user `tgrall`, including their star counts. This is achieved through the use of `useEffect` and `useState` hooks from React.
- **Updates UI**: Modifies the homepage to display the fetched repositories and their star counts in a new section. Each repository is presented with its name and star count, enhancing the informational value of the page.
- **Enhances Page Style**: Changes the background color of the entire page to black and updates the text color to yellow, adhering to the design specifications provided.

Additionally, a new documentation file `docs/index.md` is added to the project:
- **Documents Framework Version**: Specifies the version of Next.js used in the project.
- **Describes API Call Sequence**: Includes a sequence diagram using Mermaid to visually represent the flow of API calls from the homepage request to the display of repository data.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tgrall-octodemo/summerfest012024/issues/1?shareId=dfbc114d-4a5a-40a5-a0a4-ad208686aaa8).